### PR TITLE
Fix issues #10 and #13, incorporate PRs #9 and #12

### DIFF
--- a/wapt.py
+++ b/wapt.py
@@ -242,4 +242,4 @@ def install_package():
                 os.unlink(tmp_fn)
 
 if __name__ == '__main__':
-    app.run(host='127.0.0.1', port=5000)
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
README: fix ExecStart .sh extension, certificate path, http protocol, and replace download link with official Linux/macOS deployment docs.

wapt.py: route errors in search_uuid through logger instead of print, remove dead comment, return 404 when no package match is found, bind Flask to 127.0.0.1 instead of 0.0.0.0.

Close : #10 #13 